### PR TITLE
Add named fonts

### DIFF
--- a/cssgen/fonts.py
+++ b/cssgen/fonts.py
@@ -10,3 +10,5 @@ class OpiFontRenderer(object):
         opifont_node.set('height', str(font_model.size))
         opifont_node.set('style', str(font_model.style))
         opifont_node.set('pixels', str(font_model.pixels).lower())
+        if font_model.name is not None:
+            opifont_node.text = str(font_model.name)

--- a/opimodel/fonts.py
+++ b/opimodel/fonts.py
@@ -12,11 +12,15 @@ STYLES = {'regular': REGULAR,
 
 class Font(object):
 
-    def __init__(self, fontface, size, style=REGULAR, pixels=True):
+    def __init__(self, name=None, fontface='Liberation Sans',
+            size=15, style=REGULAR, pixels=True):
+        # If the font name is specified, and defined in CS-Studio's fonts.def
+        # than this overrides all over attributes.
         self.fontface = fontface
         self.size = size
         self.style = style
         self.pixels = pixels
+        self.name = name
 
     def __eq__(self, other):
         val = (self.size == other.size and

--- a/test/test_fonts.py
+++ b/test/test_fonts.py
@@ -20,7 +20,7 @@ def font_file():
 
 
 def test_add_font_to_widget(widget, get_renderer):
-    f = fonts.Font('Dummy name', 12, fonts.REGULAR)
+    f = fonts.Font(fontface='Dummy name', size=12, style=fonts.REGULAR)
     widget.set_font(f)
     renderer = get_renderer(widget)
     renderer.assemble()

--- a/test/test_fonts.py
+++ b/test/test_fonts.py
@@ -20,7 +20,7 @@ def font_file():
 
 
 def test_add_font_to_widget(widget, get_renderer):
-    f = fonts.Font(fontface='Dummy name', size=12, style=fonts.REGULAR)
+    f = fonts.Font(name='Dummy Font Name', fontface='Dummy Font Face', size=12, style=fonts.REGULAR)
     widget.set_font(f)
     renderer = get_renderer(widget)
     renderer.assemble()
@@ -29,7 +29,8 @@ def test_add_font_to_widget(widget, get_renderer):
     assert len(font_nodes) == 1
     opifont_nodes = node.findall('./font/opifont.name')
     assert len(opifont_nodes) == 1
-    assert opifont_nodes[0].get('fontName') == 'Dummy name'
+    assert opifont_nodes[0].text == 'Dummy Font Name'
+    assert opifont_nodes[0].get('fontName') == 'Dummy Font Face'
     assert opifont_nodes[0].get('height') == '12'
     assert opifont_nodes[0].get('style') == '0'
 


### PR DESCRIPTION
Added the ability to specify a font by it's 'name' as stored in the CS-Studio fonts.def file. Updated corresponding tests.