### PR TITLE
Replace ElementTree with lxml.

### DIFF
--- a/cssgen/actions.py
+++ b/cssgen/actions.py
@@ -1,4 +1,4 @@
-import xml.etree.ElementTree as et
+import lxml.etree as et
 
 
 class OpiActionRenderer(object):

--- a/cssgen/colors.py
+++ b/cssgen/colors.py
@@ -1,4 +1,4 @@
-import xml.etree.ElementTree as et
+import lxml.etree as et
 
 
 class OpiColorRenderer(object):

--- a/cssgen/fonts.py
+++ b/cssgen/fonts.py
@@ -1,4 +1,4 @@
-import xml.etree.ElementTree as et
+import lxml.etree as et
 
 
 class OpiFontRenderer(object):

--- a/cssgen/render.py
+++ b/cssgen/render.py
@@ -1,4 +1,4 @@
-import xml.etree.ElementTree as et
+import lxml.etree as et
 from cssgen import actions, rules, colors, borders, fonts
 import collections
 
@@ -83,4 +83,4 @@ class OpiRenderer(object):
     def write_to_file(self, filename):
         self.assemble()
         tree = et.ElementTree(self._node)
-        tree.write(filename)
+        tree.write(filename, pretty_print=True)

--- a/cssgen/rules.py
+++ b/cssgen/rules.py
@@ -1,4 +1,4 @@
-import xml.etree.ElementTree as et
+import lxml.etree as et
 from opimodel import rules
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+lxml
 pytest>=3.0
 coverage
 pytest-cov

--- a/test/test_borders.py
+++ b/test/test_borders.py
@@ -2,7 +2,7 @@ from opimodel import widgets, borders, colors
 
 
 def test_add_border_to_widget(widget, get_renderer):
-    w = widgets.Widget(0, 0, 0, 0, 'dummy')
+    w = widgets.Widget('dummy', 0, 0, 0, 0)
     b = borders.Border(borders.LINE_STYLE, 1, colors.BLACK, False)
     w.set_border(b)
     renderer = get_renderer(w)

--- a/test/test_rules.py
+++ b/test/test_rules.py
@@ -6,7 +6,7 @@ def test_empty_RulesNode(widget, get_renderer):
     widget.rules = []
     renderer = get_renderer(widget)
     output = str(renderer)
-    assert '<rules />' in output
+    assert '<rules/>' in output
 
 
 def test_greater_than_rule(widget, get_renderer):


### PR DESCRIPTION
This has two useful features: pretty-printing of xml and the ability to
define CDATA tags.