### PR TITLE
Codeclean

### DIFF
--- a/renderers/css/rules.py
+++ b/renderers/css/rules.py
@@ -1,4 +1,5 @@
 import lxml.etree as et
+
 from opimodel import rules
 
 

--- a/renderers/css/widget.py
+++ b/renderers/css/widget.py
@@ -1,4 +1,5 @@
 import collections
+
 import lxml.etree as et
 
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -18,4 +18,5 @@ def display():
 def get_renderer():
     def get_renderer(w):
         return render.get_opi_renderer(w)
+
     return get_renderer

--- a/test/test_borders.py
+++ b/test/test_borders.py
@@ -1,11 +1,10 @@
-from opimodel import widgets, borders, colors
+from opimodel import borders, colors
 
 
 def test_add_border_to_widget(widget, get_renderer):
-    w = widgets.Widget('dummy', 0, 0, 0, 0)
     b = borders.Border(borders.LINE_STYLE, 1, colors.BLACK, False)
-    w.set_border(b)
-    renderer = get_renderer(w)
+    widget.set_border(b)
+    renderer = get_renderer(widget)
     renderer.assemble()
     alarm_sensitive = renderer.get_node().find('./border_alarm_sensitive')
     assert alarm_sensitive.text == 'false'

--- a/test/test_fonts.py
+++ b/test/test_fonts.py
@@ -1,8 +1,9 @@
-from opimodel import fonts
-import tempfile
 import os
+import tempfile
+
 import pytest
 
+from opimodel import fonts
 
 TEST_FONT_FILE = """dummy 1 = Dummy one-bold-19pt
 dummy 2 = Dummy two-italic-15px


### PR DESCRIPTION
@willrogers Fix some small issues that were generating issues.

The one issue that remains is accessing `model._attribute` variables in the renderer (and tests). These are 'private' (by convention). With no documentation explaining how `.attribute` and `._attribute`s are handled differently in some of the renderers this is confusing.

Changing your naming convention could make it clearer these are subelements e.g model.sub_attribute in actions and rules, and remove the code-style warnings?
