### PR TITLE
Rename arguments that override builtins

### DIFF
--- a/opimodel/rules.py
+++ b/opimodel/rules.py
@@ -8,11 +8,11 @@ class Rule(object):
 
 class BetweenRule(Rule):
 
-    def __init__(self, prop_id, pv, min, max):
+    def __init__(self, prop_id, pv, min_val, max_val):
         super(BetweenRule, self).__init__(prop_id)
         self._pv = pv
-        self._min = min
-        self._max = max
+        self._min = min_val
+        self._max = max_val
 
 
 class GreaterThanRule(Rule):

--- a/opimodel/widgets.py
+++ b/opimodel/widgets.py
@@ -9,7 +9,7 @@ class HAlign(object):
 
 class Widget(object):
 
-    def __init__(self, id, x, y, width, height, name='widget'):
+    def __init__(self, type_id, x, y, width, height, name='widget'):
         self.x = x
         self.y = y
         self.width = width
@@ -17,7 +17,7 @@ class Widget(object):
         self._name = name
         self._children = []
         self._parent = None
-        self._typeId = id
+        self._typeId = type_id
 
     def get_parent(self):
         return self._parent
@@ -53,8 +53,8 @@ class ActionWidget(Widget):
 
     # No ID, designed to be subclassed only
 
-    def __init__(self, id, x, y, width, height):
-        super(ActionWidget, self).__init__(id, x, y, width, height)
+    def __init__(self, type_id, x, y, width, height):
+        super(ActionWidget, self).__init__(type_id, x, y, width, height)
         self.actions = []
 
     def add_action(self, action):


### PR DESCRIPTION
@willrogers Fixes pylint warnings that we override builtins: `id`, `max` and `min`

@mfurseman isn't using named-args in his scripts to the BetweenRule API change doesn't affect him