### PR TITLE
Add renderers.css package to setup.py.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,5 +4,5 @@ setup(name='cssgen',
       version='0.0.1',
       url='https://github.com/dls-controls/cssgen',
       license='APACHE',
-      packages=['renderers', 'opimodel'],
+      packages=['renderers', 'renderers.css', 'opimodel'],
       install_requires=['lxml'])


### PR DESCRIPTION
Subpackages are not found by default.

@nickbattam I think this explains the problems you found.