### PR TITLE
Make Rectangle extend ActionWidget.

### DIFF
--- a/opimodel/widgets.py
+++ b/opimodel/widgets.py
@@ -189,7 +189,7 @@ class Display(Widget):
         self.auto_scale_widgets = scalings.DisplayScaleOptions(min_width, min_height, autoscale)
 
 
-class Rectangle(Widget):
+class Rectangle(ActionWidget):
 
     ID = 'org.csstudio.opibuilder.widgets.Rectangle'
 


### PR DESCRIPTION
@mfurseman @nickbattam I need a rectangle to have an action.

This raises the more general question of which widgets should be ActionWidgets. It seems that in CS-Studio any widget can have actions.  Semantically, it doesn't make much sense for e.g. a line to have actions. But perhaps we could make all widgets ActionWidgets.